### PR TITLE
Fix OpenAI 1.x compatibility

### DIFF
--- a/app.py
+++ b/app.py
@@ -66,8 +66,8 @@ if not OPENAI_API_KEY:
     logger.error("OPENAI_API_KEY not set")
     raise ValueError("Please set OPENAI_API_KEY in your .env file")
 
-# Set the API key
-openai.api_key = OPENAI_API_KEY
+# Set the API key and initialize the OpenAI client
+openai_client = openai.OpenAI(api_key=OPENAI_API_KEY)
 
 # Initialize Firestore
 try:
@@ -169,7 +169,7 @@ def chat():
         token_count = count_tokens(message, model)
         logger.info(f"Chat request from user {username} - Model: {model}, Tokens: {token_count}")
 
-        response = openai.ChatCompletion.create(
+        response = openai_client.chat.completions.create(
             model=model,
             messages=[{'role': 'user', 'content': message}]
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,7 @@ MarkupSafe==3.0.2
 msgspec==0.19.0
 multidict==6.2.0
 numpy==2.2.3
-openai==0.28.1
+openai>=1.0.0
 openpyxl==3.1.5
 packaging==24.2
 pandas==2.2.3


### PR DESCRIPTION
## Summary
- instantiate `openai.OpenAI()` client and use it for chat completions
- require `openai>=1.0.0`

## Testing
- `python3 -m py_compile app.py utils.py register_user.py delete_user.py list_users.py`

------
https://chatgpt.com/codex/tasks/task_e_6851680809188320b1210a7280b76359